### PR TITLE
Fixed un-trimmed input being added to commandHistory

### DIFF
--- a/src/engine/client/gui/console/init.lua
+++ b/src/engine/client/gui/console/init.lua
@@ -61,7 +61,6 @@ end
 
 local function doCommand( self, input )
 	self.input:setText( "" )
-	input = string.trim( input )
 	print( "] " .. input )
 
 	local command = string.match( input, "^([^%s]+)" )
@@ -137,10 +136,11 @@ function console:console()
 	self.output = gui.consoletextbox( self, name .. " Output Text Box", "" )
 	self.input  = gui.textbox( self, name .. " Input Text Box", "" )
 	self.input.onEnter = function( textbox, text )
+		text = string.trim( text )
 		doCommand( self, text )
 
 		local commandHistory = gui.console.commandHistory
-		if ( not table.hasvalue( commandHistory, text ) ) then
+		if ( not table.hasvalue( commandHistory, text ) and text ~= '' ) then
 			table.insert( commandHistory, text )
 		end
 	end


### PR DESCRIPTION
-Input is now trimmed before it is added to commandHistory. It stops this happening:
![image](https://cloud.githubusercontent.com/assets/3951979/7714011/5c567fb6-fe73-11e4-8197-cf2ed03c0e16.png)


-doCommand no longer trims input because it is now done before it's called
-Empty strings don't get added to commandHistory