### PR TITLE
Fixed console history displaying things twice

### DIFF
--- a/src/engine/client/gui/console/init.lua
+++ b/src/engine/client/gui/console/init.lua
@@ -105,7 +105,7 @@ local function autocomplete( text )
 	local suggestions = {}
 
 	for command in pairs( concommand.concommands ) do
-		if ( string.find( command, text, 1, true ) == 1 ) then
+		if ( ( string.find( command, text, 1, true ) == 1 ) and ( not table.hasvalue( gui.console.commandHistory, command ) ) ) then
 			table.insert( suggestions, command .. " " )
 		end
 	end


### PR DESCRIPTION
If you enter a command (such as 'disconnect') into the console you'll have two disconnect suggestions (one from your history and one from concommand.concommands)

![image](https://cloud.githubusercontent.com/assets/3951979/7715130/e0b65bb0-fe7c-11e4-9ce3-ce011e370b16.png)

![image](https://cloud.githubusercontent.com/assets/3951979/7715128/d64dcabe-fe7c-11e4-9899-7ea3e894af0a.png)


I'm not 100% sure if this is supposed to happen or not, but it seems wrong