### PR TITLE
Moved onPlayerChat hook call from say to onChatReceived

### DIFF
--- a/src/engine/shared/entities/player.lua
+++ b/src/engine/shared/entities/player.lua
@@ -261,10 +261,7 @@ end
 
 concommand( "say", "Display player message",
 	function( self, player, command, argString, argTable )
-		if ( not game.call( "shared", "onPlayerChat", player, argString ) ) then
-			return
-		end
-
+		
 		if( _SERVER ) then
 			local payload = payload( "chat" )
 			payload:set( "entIndex", player and player.entIndex or 0 )

--- a/src/game/client/gui/hudchat.lua
+++ b/src/game/client/gui/hudchat.lua
@@ -76,6 +76,9 @@ function onChatReceived( payload )
 	if ( entIndex > 0 ) then
 		local entity = entity.getByEntIndex( entIndex )
 		chat.addText( entity:getName() .. ": " .. message )
+		if ( not game.call( "shared", "onPlayerChat", entity, message ) ) then
+			return
+		end
 	else
 		chat.addText( "SERVER: " .. message )
 	end


### PR DESCRIPTION
First I thought onPlayerChat was meant to be called only when you sent a message, but then I saw the speech bubble thingies use that hook (meaning the speech bubbles only work when you talk - doubt this is intentional)

Moving the call to onChatReceived means you'll only see the message when the server actually gets it (so the server can block messages ect) and onPlayerChat will be called when anybody sends a message (which also fixed speech bubbles)