### PR TITLE
Fixed sprite animation loop bug

### DIFF
--- a/engine/client/sprite.lua
+++ b/engine/client/sprite.lua
@@ -95,8 +95,8 @@ function sprite:update( dt )
 
 		if ( self.frame > animation.to ) then
 			local name = self:getAnimationName()
-			self:onAnimationEnd( name )
 			self.frame = animation.from
+			self:onAnimationEnd( name )
 		end
 
 		self:updateFrame()


### PR DESCRIPTION
I've called this a bugfix, but its kind of niche. The animation frame is reset *after* calling `onAnimationEnd`, which in the case of starting a new animation in `onAnimationEnd`, gives you a nice frame flicker.