### PR TITLE
Fix tobool logic for booleans.

### DIFF
--- a/engine/shared/baselib.lua
+++ b/engine/shared/baselib.lua
@@ -58,6 +58,7 @@ if ( rawprint == nil and rawtype == nil ) then
 end
 
 function toboolean( v )
+	if (type(v) == "boolean") then return v end
 	local n = tonumber( v )
 	return n ~= nil and n ~= 0
 end


### PR DESCRIPTION
baselib/toboolean logic is currently broken for booleans since `tonumber(true)` returns `nil`.

```lua
] lua_dostring print(toboolean(true))
false
```
This PR adds a type check for booleans.