### PR TITLE
Fixed table.print not tostring-ing keys

### DIFF
--- a/engine/shared/tablib.lua
+++ b/engine/shared/tablib.lua
@@ -170,7 +170,7 @@ function table.print( t, i, printed )
 	local indent = string.rep( "\t", i )
 	for k, v in pairs( t ) do
 		if ( type( v ) == "table" and not printed[ v ] ) then
-			print( indent .. k )
+			print( indent .. tostring( k ) )
 			table.print( v, i + 1, printed )
 		else
 			print( indent .. tostring( k ), v )


### PR DESCRIPTION
Quick fix to prevent `table.print` crashing with key types that are not implicitly convertible to strings (e.g. functions).

Not actually sure how good this PR actually is since it works with strings and numbers and its arguably bad design to use anything else for keys, but it might be good "future-proofing"?