### PR TITLE
Fix math.remap; Add math.remapClamp

### DIFF
--- a/engine/shared/mathlib.lua
+++ b/engine/shared/mathlib.lua
@@ -89,8 +89,12 @@ function math.pointonlinesegment( x1, y1, x2, y2, px, py )
 	return math.pointonline( x1, y1, x2, y2, px, py )
 end
 
-function math.remap( n, inMin, inMax, outMin, outMax )
-	return ( n / ( inMax - inMin ) ) * ( outMax - outMin ) + outMin
+function math.remap(v, srcLow, srcHigh, destLow, destHigh)
+    return destLow + (destHigh - destLow) * (v - srcLow) / (srcHigh - srcLow)
+end
+
+function math.remapClamp(v, srcLow, srcHigh, destLow, destHigh)
+    return destLow + (destHigh - destLow) * math.clamp((v - srcLow) / (srcHigh - srcLow), 0, 1)
 end
 
 function math.round( n )


### PR DESCRIPTION
The source range passed to math.remap is now considered properly. The mistake is only obvious with a non-zero source range low value, which is why is probably wasn't noticed before.

-- Before (wrong)
print(math.remap(15, 10, 20, 80, 90)) -- 95.0

-- After
print(math.remap(15, 10, 20, 80, 90)) -- 85.0

Also added math.remapClamp, which is similar to math.remap but the value returned is clamped to the destination range, even if the input value is beyond the source range.